### PR TITLE
detectCores can return NA

### DIFF
--- a/R/gsva.R
+++ b/R/gsva.R
@@ -445,9 +445,7 @@ compute.geneset.es <- function(expr, gset.idx.list, sample.idxs, rnaseq=FALSE,
       mclapp <- get('mclapply', envir=getNamespace('parallel'))
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       nCores <- detCor()
-      options(mc.cores=nCores)
-      if (parallel.sz > 0 && parallel.sz < nCores)
-        options(mc.cores=parallel.sz)
+      setCores(nCores)
 
       pb <- NULL
       if (verbose){
@@ -578,6 +576,22 @@ rndWalk <- function(gSetIdx, geneRanking, j, R, alpha) {
   sum(walkStat) 
 }
 
+setCores <- function() {
+  if(is.na(nCores)) {
+    if (parallel.sz > 0) {
+      options(mc.cores=parallel.sz)
+    } else {
+      options(mc.cores=1)
+    }
+  } else {
+    if (parallel.sz > 0 && parallel.sz < nCores) {
+      options(mc.cores=parallel.sz)
+    } else {
+      options(mc.cores=nCores)
+    }
+  }
+}
+
 ssgsea <- function(X, geneSets, alpha=0.25, parallel.sz,
                    parallel.type, normalization=TRUE, verbose) {
 
@@ -616,9 +630,7 @@ ssgsea <- function(X, geneSets, alpha=0.25, parallel.sz,
       mclapp <- get('mclapply', envir=getNamespace('parallel'))
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       nCores <- detCor()
-      options(mc.cores=nCores)
-      if (parallel.sz > 0 && parallel.sz < nCores)
-        options(mc.cores=parallel.sz)
+      setCores(nCores)
       if (verbose)
         cat("Using parallel with", getOption("mc.cores"), "cores\n")
     }
@@ -709,9 +721,7 @@ zscore <- function(X, geneSets, parallel.sz, parallel.type, verbose) {
       mclapp <- get('mclapply', envir=getNamespace('parallel'))
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       nCores <- detCor()
-      options(mc.cores=nCores)
-      if (parallel.sz > 0 && parallel.sz < nCores)
-        options(mc.cores=parallel.sz)
+      setCores(nCores)
       if (verbose)
         cat("Using parallel with", getOption("mc.cores"), "cores\n")
     }
@@ -801,9 +811,7 @@ plage <- function(X, geneSets, parallel.sz, parallel.type, verbose) {
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       ## masterDesc <- get('masterDescriptor', envir=getNamespace('parallel'))
       nCores <- detCor()
-      options(mc.cores=nCores)
-      if (parallel.sz > 0 && parallel.sz < nCores)
-        options(mc.cores=parallel.sz)
+      setCores(nCores)
       if (verbose)
         cat("Using parallel with", getOption("mc.cores"), "cores\n")
     }

--- a/R/gsva.R
+++ b/R/gsva.R
@@ -576,7 +576,7 @@ rndWalk <- function(gSetIdx, geneRanking, j, R, alpha) {
   sum(walkStat) 
 }
 
-setCores <- function() {
+setCores <- function(nCores) {
   if(is.na(nCores)) {
     if (parallel.sz > 0) {
       options(mc.cores=parallel.sz)

--- a/R/gsva.R
+++ b/R/gsva.R
@@ -445,7 +445,7 @@ compute.geneset.es <- function(expr, gset.idx.list, sample.idxs, rnaseq=FALSE,
       mclapp <- get('mclapply', envir=getNamespace('parallel'))
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       nCores <- detCor()
-      setCores(nCores)
+      setCores(nCores, parallel.sz)
 
       pb <- NULL
       if (verbose){
@@ -576,7 +576,7 @@ rndWalk <- function(gSetIdx, geneRanking, j, R, alpha) {
   sum(walkStat) 
 }
 
-setCores <- function(nCores) {
+setCores <- function(nCores, parallel.sz) {
   if(is.na(nCores)) {
     if (parallel.sz > 0) {
       options(mc.cores=parallel.sz)
@@ -630,7 +630,7 @@ ssgsea <- function(X, geneSets, alpha=0.25, parallel.sz,
       mclapp <- get('mclapply', envir=getNamespace('parallel'))
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       nCores <- detCor()
-      setCores(nCores)
+      setCores(nCores, parallel.sz)
       if (verbose)
         cat("Using parallel with", getOption("mc.cores"), "cores\n")
     }
@@ -721,7 +721,7 @@ zscore <- function(X, geneSets, parallel.sz, parallel.type, verbose) {
       mclapp <- get('mclapply', envir=getNamespace('parallel'))
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       nCores <- detCor()
-      setCores(nCores)
+      setCores(nCores, parallel.sz)
       if (verbose)
         cat("Using parallel with", getOption("mc.cores"), "cores\n")
     }
@@ -811,7 +811,7 @@ plage <- function(X, geneSets, parallel.sz, parallel.type, verbose) {
       detCor <- get('detectCores', envir=getNamespace('parallel'))
       ## masterDesc <- get('masterDescriptor', envir=getNamespace('parallel'))
       nCores <- detCor()
-      setCores(nCores)
+      setCores(nCores, parallel.sz)
       if (verbose)
         cat("Using parallel with", getOption("mc.cores"), "cores\n")
     }


### PR DESCRIPTION
While using GSVA in Rstudio in a docker container I encountered a scenario where parallel::detectCores() returns NA instead of an integer number of cores. GSVA does not handle this logic and crashes as a result. This pull request resolves the issue. This can be seen by running the attached proof of concept code which follows the GSVA example in one of the vignettes. The code runs two tests, one where the detectCores behaves as expected and returns an integer number of cores, and one where it returns NA. Running the POC with the GSVA version at the HEAD of this repo will cause a failure. Running with the POC with the GSVA version at the HEAD version of my fork outputs 

```
[1] "good, success"
[1] "bad, success"
```
which means it is robust in the case that detectCores() fails.

Proof of concept code follows:

```
library(parallel)
library(GSVA)

# setup from vignette
p <- 20000    ## number of genes
n <- 30       ## number of samples
nGS <- 100    ## number of gene sets
min.sz <- 10  ## minimum gene set size
max.sz <- 100 ## maximum gene set size
X <- matrix(rnorm(p*n), nrow=p, dimnames=list(1:p, 1:n))
gs <- as.list(sample(min.sz:max.sz, size=nGS, replace=TRUE)) ## sample gene set sizes
gs <- lapply(gs, function(n, p) sample(1:p, size=n, replace=FALSE), p) ## sample gene sets

my.good.detectCores = function() {
  return(1)
}
assignInNamespace("detectCores", my.good.detectCores, ns="parallel", envir=as.environment("package:parallel"))
es.max <- gsva(X, gs, mx.diff=FALSE, verbose=FALSE, parallel.sz=1)
print('good, success')

my.bad.detectCores = function() {
  return(NA)
}
assignInNamespace("detectCores", my.bad.detectCores, ns="parallel", envir=as.environment("package:parallel"))
es.max <- gsva(X, gs, mx.diff=FALSE, verbose=FALSE, parallel.sz=1)
print('bad, success')
```
