### PR TITLE
adding sparse support to zscore method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GSVA
-Version: 1.39.5
+Version: 1.39.6
 Title: Gene Set Variation Analysis for microarray and RNA-seq data
 Authors@R: c(person("Justin", "Guinney", role=c("aut", "cre"), email="justin.guinney@sagebase.org"),
              person("Robert", "Castelo", role="aut", email="robert.castelo@upf.edu"),

--- a/inst/unitTests/test_sparseMethods.R
+++ b/inst/unitTests/test_sparseMethods.R
@@ -10,4 +10,5 @@ test_sparseMethods <- function(){
   
   checkEqualsNumeric(gsva(m, gene.sets), gsva(M, gene.sets))
   checkEqualsNumeric(gsva(m, gene.sets, method="plage"), gsva(M, gene.sets, method="plage"))
+  checkEqualsNumeric(gsva(m, gene.sets, method="zscore"), gsva(M, gene.sets, method="zscore"))
 }


### PR DESCRIPTION
- added sparse support to zscore method
- changed a little the message that informs that choice in ignoring non-zeroe values in scaling dgCMatrix is provisional