### PR TITLE
take out shinythemes from global

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GSVA
-Version: 1.39.32
+Version: 1.39.33
 Title: Gene Set Variation Analysis for microarray and RNA-seq data
 Authors@R: c(person("Justin", "Guinney", role=c("aut", "cre"), email="justin.guinney@sagebase.org"),
              person("Robert", "Castelo", role="aut", email="robert.castelo@upf.edu"),

--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -1,6 +1,5 @@
 ### LOADING LIBRARIES
 library(shiny)
-library(shinythemes)
 library(plotly)
 library(GSVA)
 library(GSEABase)


### PR DESCRIPTION
- fixed little bug: taking out `library(shinythemes)` from `global.R `(we don't use that library anymore)