### PR TITLE
fix #77 by adding the missing function call

### DIFF
--- a/src/register_cmethods.c
+++ b/src/register_cmethods.c
@@ -29,4 +29,5 @@ cMethods[] = {
 void
 R_init_GSVA(DllInfo *info) {
   R_registerRoutines(info, cMethods, NULL, NULL, NULL);
+  R_useDynamicSymbols(info, FALSE);
 }


### PR DESCRIPTION
fix #77 by adding the missing function call

This will fix one of the two check notes on C level.

The second is caused by R's gcc flags that can be viewed using `R CMD config CFLAGS` and
modified by adding e.g. the following line to your Dockerfile:
```
RUN echo "CFLAGS=-Wall -g -O2 -fPIC" > ${R_HOME}/etc/Makevars.site
```
