### PR TITLE
modify zscore,not iterate over all cells

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -54,14 +54,15 @@ importFrom(BiocParallel, SerialParam,
 importFrom(SingleCellExperiment, SingleCellExperiment)
 importFrom(sparseMatrixStats, colRanks)
 importFrom(DelayedArray, rowAutoGrid,
-			  colAutoGrid,
-			  defaultAutoGrid,
-			  currentBlockId,
-			  read_block, 
-			  gridReduce,
-			  write_block,
-			  close,
-			  t)
+                         colAutoGrid,
+                         defaultAutoGrid,
+                         currentBlockId,
+                         read_block, 
+                         gridReduce,
+                         write_block,
+                         close,
+                         t,
+                         colSums)
 importFrom(HDF5Array, HDF5RealizationSink,
                       writeHDF5Array)
 importFrom(DelayedMatrixStats, rowSds)

--- a/R/gsva.R
+++ b/R/gsva.R
@@ -898,10 +898,7 @@ ssgsea <- function(X, geneSets, alpha=0.25, parallel.sz,
 combinez <- function(gSetIdx, j, Z) sum(Z[gSetIdx, j]) / sqrt(length(gSetIdx))
 
 zscore <- function(X, geneSets, parallel.sz, verbose=TRUE,
-                   BPPARAM=SerialParam(progressbar=verbose)) {
-
-  n <- ncol(X)
-
+                   BPPARAM=SerialParam(progressbar = verbose)) {
   if(is(X, "dgCMatrix")){
     message("Please bear in mind that this method first scales the values of the gene
     expression data. In order to take advantage of the sparse Matrix type, the scaling
@@ -911,25 +908,14 @@ zscore <- function(X, geneSets, parallel.sz, verbose=TRUE,
     Z <- t(X)
     Z <- .dgCapply(Z, scale, 2)
     Z <- t(Z)
-    
   } else {
     Z <- t(scale(t(X)))
   }
-
-  es <- bplapply(as.list(1:n), function(j, Z, geneSets) {
-    es_sample <- lapply(geneSets, combinez, j, Z)
-    unlist(es_sample)
-  }, Z, geneSets, BPPARAM=BPPARAM)
-
-  es <- do.call("cbind", es)
+  es <- bplapply(geneSets, function(gSetIdx) {
+    colSums(Z[gSetIdx, ]) / sqrt(length(gSetIdx))
+  },BPPARAM=BPPARAM)
   
-  if(is(X, "dgCMatrix")){
-    es <- as(as(as(es, "dMatrix"), "generalMatrix"), "CsparseMatrix")
-  }
-
-  rownames(es) <- names(geneSets)
-  colnames(es) <- colnames(X)
-
+  es <- do.call("rbind",es)
   es
 }
 


### PR DESCRIPTION
Updated code, better performance wise, consistent results.
You can test the new code and the old code like the following sample code.
```R
zscros_old <- function(X, geneSets, parallel.sz, verbose=TRUE,
         BPPARAM=SerialParam(progressbar=verbose)) {
  
  n <- ncol(X)
  
  if(is(X, "dgCMatrix")){
    message("Please bear in mind that this method first scales the values of the gene
    expression data. In order to take advantage of the sparse Matrix type, the scaling
    will only be applied to the non-zero values of the data. This is a provisional 
    solution in order to give support to the dgCMatrix format.")
    
    Z <- t(X)
    Z <- .dgCapply(Z, scale, 2)
    Z <- t(Z)
  } else {
    Z <- t(scale(t(X)))
  }

  es <- bplapply(as.list(1:n), function(j, Z, geneSets) {
    es_sample <- lapply(geneSets, combinez, j, Z)
    unlist(es_sample)
  }, Z, geneSets, BPPARAM=BPPARAM)
  
  es <- do.call("cbind", es)
  
  if(is(X, "dgCMatrix")){
    es <- as(as(as(es, "dMatrix"), "generalMatrix"), "CsparseMatrix")
  }
  
  rownames(es) <- names(geneSets)
  colnames(es) <- colnames(X)
  
  es
}

zscore <- function(X, geneSets, parallel.sz, verbose=TRUE,
                   BPPARAM=SerialParam(progressbar = verbose)) {
  if(is(X, "dgCMatrix")){
    message("Please bear in mind that this method first scales the values of the gene
    expression data. In order to take advantage of the sparse Matrix type, the scaling
    will only be applied to the non-zero values of the data. This is a provisional 
    solution in order to give support to the dgCMatrix format.")
    
    Z <- t(X)
    Z <- .dgCapply(Z, scale, 2)
    Z <- t(Z)
  } else {
    Z <- t(scale(t(X)))
  }
  es <- bplapply(geneSets, function(gSetIdx) {
    colSums(Z[gSetIdx, ]) / sqrt(length(gSetIdx))
  },BPPARAM=BPPARAM)
  
  es <- do.call("rbind",es)
  es
}
# X is sparse matrix
X <- GSVA:::.filterFeatures(X,method = "zscore")
geneSets <- list(
  set1 = sample(seq_len(nrow(X)),size = 10),
  set2 = sample(seq_len(nrow(X)),size = 177)
)

result <- bench::mark(
  a1 <- as.matrix(zscros_old(X,geneSets,parallel.sz = 1)),
  a2 <- zscore(X,geneSets,parallel.sz = 1),
  iterations = 1
)
```
After testing, in the case of 10,000 single-cell data, the performance has been greatly improved.