### PR TITLE
move igsva() Shiny app to new API; fix two UI buglets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GSVA
-Version: 1.51.1
+Version: 1.51.2
 Title: Gene Set Variation Analysis for Microarray and RNA-Seq Data
 Authors@R: c(person("Robert", "Castelo", role=c("aut", "cre"), email="robert.castelo@upf.edu"),
              person("Justin", "Guinney", role="aut", email="jguinney@gmail.com"),

--- a/inst/shinyApp/argumentsDataModule.R
+++ b/inst/shinyApp/argumentsDataModule.R
@@ -17,16 +17,16 @@ argumentsDataUI <- function(id) {
                   choices = methodChoices),
       selectInput(ns("kcdf"), "kcdf",
                   c("Gaussian","Poisson","none")),
-      radioButtons(ns("absRanking"), "abs.ranking:",
+      radioButtons(ns("absRanking"), "absRanking:",
                    c("False" = FALSE,
                      "True" = TRUE)),
-      numericInput(ns("minSz"),"min.sz", value = 1),
-      numericInput(ns("maxSz"),"max.sz (Write 0 for infinite)", value = 0),
-      radioButtons(ns("mxDiff"), "mx.diff",
+      numericInput(ns("minSz"),"minSize", value = 1),
+      numericInput(ns("maxSz"),"maxSize (Write 0 for infinite)", value = 0),
+      radioButtons(ns("mxDiff"), "maxDiff",
                    c("True" = TRUE,
                      "False" = FALSE)),
       numericInput(ns("tau"),"tau", value = 1),
-      radioButtons(ns("ssgseaNorm"), "ssgsea.norm:",
+      radioButtons(ns("ssgseaNorm"), "normalize:",
                    c("True" = TRUE,
                      "False" = FALSE))
     )
@@ -37,7 +37,7 @@ argumentsDataServer <- function(id){
   moduleServer(id, function(input, output, session){
     
     observeEvent(input$method, {
-      toggleElement("kcdf", condition = input$method %in% c("gsva", "ssgsea"))
+      toggleElement("kcdf", condition = input$method %in% c("gsva"))
       toggleElement("absRanking", condition = input$method %in% "gsva")
       toggleElement("ssgseaNorm", condition = input$method %in% "ssgsea")
       toggleElement("mxDiff", condition = input$method %in% "gsva")
@@ -55,16 +55,15 @@ argumentsDataServer <- function(id){
       
     })
     
-    #"absRanking", "ssgseaNorm", "mxDiff", "tau"
     varMinsz <-  reactive({
-      validate(need(!is.na(input$minSz), "Value 'min.sz' cannot be empty and must be an integer value"))
+      validate(need(!is.na(input$minSz), "Value 'minSize' cannot be empty and must be an integer value"))
       input$minSz })
     varMaxsz <- reactive({
-      validate(need(!is.na(input$maxSz), "Value 'max.sz' cannot be empty and must be an integer value"))
+      validate(need(!is.na(input$maxSz), "Value 'maxSize' cannot be empty and must be an integer value"))
       ifelse(input$maxSz==0, Inf, input$maxSz) })
     selectedTau <-  reactive({
       if(input$method %in% c("gsva", "ssgsea")){
-        validate(need(!is.na(input$tau), "Value 'tau' cannot be empty and must be an integer value"))
+        validate(need(!is.na(input$tau), "Value 'tau' cannot be empty and must be an numeric value"))
         input$tau
       } else {
         NULL

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -57,20 +57,37 @@ function(input, output, session) {
     future({
       ## sink() will redirect all console cats and prints to a
       ## text file that the main session will be reading in order
-      ## to print the progress bar from bplaply()
+      ## to print the progress bar from bplapply()
       sink(rout)
-      result <- gsva(isolate(matrix()),
-                     isolate(genesets()), 
-                     method=isolate(argInp$method()),
-                     kcdf=isolate(argInp$kcdf()),
-                     abs.ranking=isolate(argInp$absRanking()),
-                     min.sz= isolate(argInp$varMinsz()),
-                     max.sz=isolate(argInp$varMaxsz()),
-                     parallel.sz=1L, ## by now, disable parallelism
-                     mx.diff=isolate(argInp$mxDiff()),
-                     tau=isolate(argInp$selectedTau()),
-                     ssgsea.norm=isolate(argInp$ssgseaNorm()),
-                     verbose=TRUE)
+
+      param <- switch(EXPR=isolate(argInp[["method"]]()),
+                      plage=plageParam(
+                          exprData=isolate(matrix()),
+                          geneSets=isolate(genesets()),
+                          minSize=isolate(argInp[["varMinsz"]]()),
+                          maxSize=isolate(argInp[["varMaxsz"]]())),
+                      zscore=zscoreParam(
+                          exprData=isolate(matrix()),
+                          geneSets=isolate(genesets()),
+                          minSize=isolate(argInp[["varMinsz"]]()),
+                          maxSize=isolate(argInp[["varMaxsz"]]())),
+                      ssgsea=ssgseaParam(
+                          exprData=isolate(matrix()),
+                          geneSets=isolate(genesets()),
+                          minSize=isolate(argInp[["varMinsz"]]()),
+                          maxSize=isolate(argInp[["varMaxsz"]]()),
+                          alpha=isolate(argInp[["selectedTau"]]()),
+                          normalize=isolate(argInp[["ssgseaNorm"]]())),
+                      gsvaParam(
+                          exprData=isolate(matrix()),
+                          geneSets=isolate(genesets()),
+                          minSize=isolate(argInp[["varMinsz"]]()),
+                          maxSize=isolate(argInp[["varMaxsz"]]()),
+                          kcdf=isolate(argInp[["kcdf"]]()),
+                          tau=isolate(argInp[["selectedTau"]]()),
+                          maxDiff=isolate(argInp[["mxDiff"]]()),
+                          absRanking=isolate(argInp[["absRanking"]]())))
+      result <- gsva(expr=param, verbose=TRUE)
       sink()
       ## when gsva() ends, we reset the console text file to empty
       write("", file=rout)


### PR DESCRIPTION
- the `igsva()` Shiny app's only `gsva()` call in server.R has been modified to make use of parameter objects and hence the new API
- the Shiny UI no longer allows setting parameter `kcdf` when method is `ssGSEA`
- a Shiny UI error message asking for an 'integer' value for parameter `tau` has been changed to 'numeric'
- version bump to 1.51.2

resolves #127 