### PR TITLE
fix issue by updating argument name used in shiny app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: GSVA
-Version: 1.53.0
+Version: 1.53.1
 Title: Gene Set Variation Analysis for Microarray and RNA-Seq Data
 Authors@R: c(person("Robert", "Castelo", role=c("aut", "cre"), email="robert.castelo@upf.edu"),
              person("Justin", "Guinney", role="aut", email="jguinney@gmail.com"),

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -87,7 +87,7 @@ function(input, output, session) {
                           tau=isolate(argInp[["selectedTau"]]()),
                           maxDiff=isolate(argInp[["mxDiff"]]()),
                           absRanking=isolate(argInp[["absRanking"]]())))
-      result <- gsva(expr=param, verbose=TRUE)
+      result <- gsva(param=param, verbose=TRUE)
       sink()
       ## when gsva() ends, we reset the console text file to empty
       write("", file=rout)


### PR DESCRIPTION
Due to a simple oversight, the call to `../inst/shinyApp/server.R` called `gsva(expr=.)` instead of `gsva(param=.)` and thereby triggered the defunct error message instead of executing as expected. 