### PR TITLE
change misleading warning messages

### DIFF
--- a/R/gsvaDelayedArray.R
+++ b/R/gsvaDelayedArray.R
@@ -15,7 +15,7 @@
     stop("The gene set list is empty! Filter may be too stringent.")
   
   if (any(lengths(gset.idx.list) == 1))
-    warning("Some gene sets have size one. Consider setting 'minSize > 1'.")
+    warning("Some gene sets have size one. Consider setting 'minSize' to a value > 1.")
   
   parallel.sz <- as.integer(parallel.sz)
   if (parallel.sz < 1L)

--- a/R/utils.R
+++ b/R/utils.R
@@ -115,7 +115,7 @@
         stop("The gene set list contains duplicated gene set names.")
 
     if(any(lengths(filteredMappedGeneSets) == 1))
-        warning("Some gene sets have size one. Consider setting 'minSize > 1'.")
+        warning("Some gene sets have size one. Consider setting 'minSize' to a value > 1.")
 
     return(list(filteredDataMatrix=filteredDataMatrix,
                 filteredMappedGeneSets=filteredMappedGeneSets))


### PR DESCRIPTION
`Consider setting 'minSize > 1'.` as part of a warning message can be misleading, in particular because of the apparently quoted expression.  

Replaced by `Consider setting 'minSize' to a value > 1.` which hopefully avoids that.