### PR TITLE
First implementation of a missing data policy for ssGSEA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ BugReports: https://github.com/rcastelo/GSVA/issues
 Encoding: UTF-8
 biocViews: FunctionalGenomics, Microarray, RNASeq, Pathways, GeneSetEnrichment
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -169,10 +169,13 @@ setClass("zscoreParam",
 #'
 #' @slot checkNA Character string. One of the strings `"auto"` (default),
 #' `"yes"`, or `"no"`, which refer to whether the input expression data should
-#' be checked for the presence of missing (`NA`) values; see [`ssgseaParam`].
+#' be checked for the presence of missing (`NA`) values.
+#'
+#' @slot didCheckNA Logical vector of length 1, indicating whether the input
+#' expression data was checked for the presence of missing (`NA`) values.
 #'
 #' @slot anyNA Logical vector of length 1, indicating whether the input
-#' expression data contains missing (`NA`) values; see [`ssgseaParam`].
+#' expression data contains missing (`NA`) values.
 #'
 #' @slot use Character string. One of the strings `"everything"` (default),
 #' `"all.obs"`, or `"na.rm"`, which refer to three different policies to apply
@@ -194,6 +197,7 @@ setClass("ssgseaParam",
          slots=c(alpha="numeric",
                  normalize="logical",
                  checkNA="character",
+                 didCheckNA="logical",
                  anyNA="logical",
                  use="character"),
          contains="GsvaMethodParam",
@@ -206,6 +210,7 @@ setClass("ssgseaParam",
                         alpha=NA_real_,
                         normalize=NA,
                         checkNA=NA_character_,
+                        didCheckNA=NA,
                         anyNA=NA,
                         use=NA_character_))
 

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -171,6 +171,9 @@ setClass("zscoreParam",
 #' `"yes"`, or `"no"`, which refer to whether the input expression data should
 #' be checked for the presence of missing (`NA`) values; see [`ssgseaParam`].
 #'
+#' @slot anyNA Logical vector of length 1, indicating whether the input
+#' expression data contains missing (`NA`) values; see [`ssgseaParam`].
+#'
 #' @slot use Character string. One of the strings `"everything"` (default),
 #' `"all.obs"`, or `"na.rm"`, which refer to three different policies to apply
 #' in the presence of missing values in the input expression data; see
@@ -191,6 +194,7 @@ setClass("ssgseaParam",
          slots=c(alpha="numeric",
                  normalize="logical",
                  checkNA="character",
+                 anyNA="logical",
                  use="character"),
          contains="GsvaMethodParam",
          prototype=list(exprData=NULL,
@@ -202,6 +206,7 @@ setClass("ssgseaParam",
                         alpha=NA_real_,
                         normalize=NA,
                         checkNA=NA_character_,
+                        anyNA=NA,
                         use=NA_character_))
 
 

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -167,6 +167,15 @@ setClass("zscoreParam",
 #' difference between the minimum and the maximum, as described in their paper.
 #' Otherwise this last normalization step is skipped.
 #'
+#' @slot checkNA Character string. One of the strings `"auto"` (default),
+#' `"yes"`, or `"no"`, which refer to whether the input expression data should
+#' be checked for the presence of missing (`NA`) values; see [`ssgseaParam`].
+#'
+#' @slot use Character string. One of the strings `"everything"` (default),
+#' `"all.obs"`, or `"na.rm"`, which refer to three different policies to apply
+#' in the presence of missing values in the input expression data; see
+#' [`ssgseaParam`].
+#'
 #' @seealso
 #' [`GsvaExprData-class`],
 #' [`GsvaGeneSets-class`],
@@ -180,7 +189,9 @@ setClass("zscoreParam",
 #' @exportClass ssgseaParam
 setClass("ssgseaParam",
          slots=c(alpha="numeric",
-                 normalize="logical"),
+                 normalize="logical",
+                 checkNA="character",
+                 use="character"),
          contains="GsvaMethodParam",
          prototype=list(exprData=NULL,
                         geneSets=NULL,
@@ -189,7 +200,9 @@ setClass("ssgseaParam",
                         minSize=NA_integer_,
                         maxSize=NA_integer_,
                         alpha=NA_real_,
-                        normalize=NA))
+                        normalize=NA,
+                        checkNA=NA_character_,
+                        use=NA_character_))
 
 
 ## ----- GSVA Parameter Class -----

--- a/R/gsvaNewAPI.R
+++ b/R/gsvaNewAPI.R
@@ -219,19 +219,11 @@ setMethod("gsva", signature(param="ssgseaParam"),
                   cat("Estimating ssGSEA scores for",
                       length(filteredMappedGeneSets), "gene sets.\n")
 
-              autonaclasseswocheck <- c("matrix", "ExpressionSet",
-                                        "SummarizedExperiment")
-              check_na <- TRUE
-              if (checkNA(param) == "no" ||
-                  all(!class(get_exprData(param)) %in% autonaclasseswocheck))
-                  check_na <- FALSE
-
-
               ssgseaScores <- ssgsea(X=filteredDataMatrix,
                                      geneSets=filteredMappedGeneSets,
                                      alpha=get_alpha(param), 
                                      normalization=do_normalize(param),
-                                     check_na=check_na,
+                                     any_na=anyNA(param),
                                      na_use=na_use(param),
                                      minSize=get_minSize(param),
                                      verbose=verbose,

--- a/R/gsvaNewAPI.R
+++ b/R/gsvaNewAPI.R
@@ -211,18 +211,29 @@ setMethod("gsva", signature(param="ssgseaParam"),
               filteredMappedGeneSets <- famGaGS[["filteredMappedGeneSets"]]
 
               if (!inherits(BPPARAM, "SerialParam") && verbose)
-                  cat(sprintf("Setting parallel calculations through a %s back-end\n",
-                              "with workers=%d and tasks=100.\n",
+                  cat(sprintf("Setting parallel calculations through a %s\n",
+                              "back-end with workers=%d and tasks=100.\n",
                               class(BPPARAM), bpnworkers(BPPARAM)))
 
               if(verbose)
                   cat("Estimating ssGSEA scores for",
                       length(filteredMappedGeneSets), "gene sets.\n")
 
+              autonaclasseswocheck <- c("matrix", "ExpressionSet",
+                                        "SummarizedExperiment")
+              check_na <- TRUE
+              if (checkNA(param) == "no" ||
+                  all(!class(get_exprData(param)) %in% autonaclasseswocheck))
+                  check_na <- FALSE
+
+
               ssgseaScores <- ssgsea(X=filteredDataMatrix,
                                      geneSets=filteredMappedGeneSets,
                                      alpha=get_alpha(param), 
                                      normalization=do_normalize(param),
+                                     check_na=check_na,
+                                     na_use=na_use(param),
+                                     minSize=get_minSize(param),
                                      verbose=verbose,
                                      BPPARAM=BPPARAM)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,7 +20,7 @@
 ##  an SD of 0 and therefore scaling them will result in division by 0.
 
 .filterGenes <- function(expr, removeConstant=TRUE, removeNzConstant=TRUE) {
-    geneRanges <- rowRanges(expr, useNames=FALSE)
+    geneRanges <- rowRanges(expr, na.rm=TRUE, useNames=FALSE)
     constantGenes <- (geneRanges[, 1] == geneRanges[, 2])
 
     if(any(constantGenes) || anyNA(constantGenes)) {

--- a/man/ssgseaParam-class.Rd
+++ b/man/ssgseaParam-class.Rd
@@ -4,6 +4,7 @@
 \name{ssgseaParam-class}
 \alias{ssgseaParam-class}
 \alias{ssgseaParam}
+\alias{anyNA,ssgseaParam-method}
 \title{\code{ssgseaParam} class}
 \usage{
 ssgseaParam(
@@ -18,6 +19,8 @@ ssgseaParam(
   checkNA = c("auto", "yes", "no"),
   use = c("everything", "all.obs", "na.rm")
 )
+
+\S4method{anyNA}{ssgseaParam}(x, recursive = FALSE)
 }
 \arguments{
 \item{exprData}{The expression data.  Must be one of the classes
@@ -74,6 +77,10 @@ giving a warning when that happens. When \code{use="all.obs"}, the presence of
 \code{use="na.rm"}, \code{NA} values in the input expression data will be removed from
 calculations, giving a warning when that happens, and giving an error if no
 values are left after removing the \code{NA} values.}
+
+\item{x}{An object of class \code{\link{ssgseaParam}}.}
+
+\item{recursive}{Not used with \code{x} being an object of class \code{\link{ssgseaParam}}.}
 }
 \value{
 A new \code{\linkS4class{ssgseaParam}} object.
@@ -107,6 +114,9 @@ Otherwise this last normalization step is skipped.}
 \item{\code{checkNA}}{Character string. One of the strings \code{"auto"} (default),
 \code{"yes"}, or \code{"no"}, which refer to whether the input expression data should
 be checked for the presence of missing (\code{NA}) values; see \code{\link{ssgseaParam}}.}
+
+\item{\code{anyNA}}{Logical vector of length 1, indicating whether the input
+expression data contains missing (\code{NA}) values; see \code{\link{ssgseaParam}}.}
 
 \item{\code{use}}{Character string. One of the strings \code{"everything"} (default),
 \code{"all.obs"}, or \code{"na.rm"}, which refer to three different policies to apply

--- a/man/ssgseaParam-class.Rd
+++ b/man/ssgseaParam-class.Rd
@@ -113,10 +113,13 @@ Otherwise this last normalization step is skipped.}
 
 \item{\code{checkNA}}{Character string. One of the strings \code{"auto"} (default),
 \code{"yes"}, or \code{"no"}, which refer to whether the input expression data should
-be checked for the presence of missing (\code{NA}) values; see \code{\link{ssgseaParam}}.}
+be checked for the presence of missing (\code{NA}) values.}
+
+\item{\code{didCheckNA}}{Logical vector of length 1, indicating whether the input
+expression data was checked for the presence of missing (\code{NA}) values.}
 
 \item{\code{anyNA}}{Logical vector of length 1, indicating whether the input
-expression data contains missing (\code{NA}) values; see \code{\link{ssgseaParam}}.}
+expression data contains missing (\code{NA}) values.}
 
 \item{\code{use}}{Character string. One of the strings \code{"everything"} (default),
 \code{"all.obs"}, or \code{"na.rm"}, which refer to three different policies to apply

--- a/man/ssgseaParam-class.Rd
+++ b/man/ssgseaParam-class.Rd
@@ -14,7 +14,9 @@ ssgseaParam(
   minSize = 1,
   maxSize = Inf,
   alpha = 0.25,
-  normalize = TRUE
+  normalize = TRUE,
+  checkNA = c("auto", "yes", "no"),
+  use = c("everything", "all.obs", "na.rm")
 )
 }
 \arguments{
@@ -44,10 +46,34 @@ mapping. By default, the maximum size is \code{Inf}.}
 weight of the tail in the random walk performed by the \code{ssGSEA} (Barbie et
 al., 2009) method.  The default value is 0.25 as described in the paper.}
 
-\item{normalize}{Logical vector of length 1; if \code{TRUE}  runs the \code{ssGSEA} method
-from Barbie et al. (2009) normalizing the scores by the absolute difference
-between the minimum and the maximum, as described in their paper. Otherwise
-this last normalization step is skipped.}
+\item{normalize}{Logical vector of length 1; if \code{TRUE} runs the \code{ssGSEA}
+method from Barbie et al. (2009) normalizing the scores by the absolute
+difference between the minimum and the maximum, as described in their paper.
+Otherwise this last normalization step is skipped.}
+
+\item{checkNA}{Character string specifying whether the input expression data
+should be checked for the presence of missing (\code{NA}) values. This must be
+one of the strings \code{"auto"} (default), \code{"yes"}, or \code{"no"}. The default value
+\code{"auto"} means that the software will perform that check only when the input
+expression data is provided as a base \code{\link{matrix}}, an \code{\link{ExpressionSet}} or a
+\code{\link{SummarizedExperiment}} object, while every other type of input expression
+data container (e.g., \code{\link{SingleCellExperiment}}, etc.) will not be checked.
+If \code{checkNA="yes"}, then the input expression data will be checked for
+missing values irrespective of the object class of the data container, and
+if \code{checkNA="no"}, then that check will not be performed.}
+
+\item{use}{Character string specifying a policy for dealing with missing
+values (\code{NA}s) in the input expression data argument \code{exprData}. It only
+applies when either \code{checkNA="yes"}, or \code{checkNA="auto"} (see the \code{checkNA}
+parameter. The argument value must be one of the strings \code{"everything"}
+(default), \code{"all.obs"}, or \code{"na.rm"}. The policy of the default value
+\code{"everything"} consists of propagating \code{NA}s so that the resulting enrichment
+scores will be \code{NA}, whenever one or more of its contributing values is \code{NA},
+giving a warning when that happens. When \code{use="all.obs"}, the presence of
+\code{NA}s in the input expression data will produce an error. Finally, when
+\code{use="na.rm"}, \code{NA} values in the input expression data will be removed from
+calculations, giving a warning when that happens, and giving an error if no
+values are left after removing the \code{NA} values.}
 }
 \value{
 A new \code{\linkS4class{ssgseaParam}} object.
@@ -77,6 +103,15 @@ al., 2009) method.}
 method from Barbie et al. (2009) normalizing the scores by the absolute
 difference between the minimum and the maximum, as described in their paper.
 Otherwise this last normalization step is skipped.}
+
+\item{\code{checkNA}}{Character string. One of the strings \code{"auto"} (default),
+\code{"yes"}, or \code{"no"}, which refer to whether the input expression data should
+be checked for the presence of missing (\code{NA}) values; see \code{\link{ssgseaParam}}.}
+
+\item{\code{use}}{Character string. One of the strings \code{"everything"} (default),
+\code{"all.obs"}, or \code{"na.rm"}, which refer to three different policies to apply
+in the presence of missing values in the input expression data; see
+\code{\link{ssgseaParam}}.}
 }}
 
 \examples{


### PR DESCRIPTION
Missing data policy for ssGSEA, as per feature request in #168, it resolves #174. Checking for the presence of missing (`NA`) values is done through the function `anyNA()`. By default, such a check will only occur when the input expression data container is a base `matrix`, an `ExpressionSet`, or a `SummarizedExperiment`, otherwise it will be assumed that there are no missing values. This can be overridden with the argument `checkNA="yes"` or `checkNA="no"`, at parameter construction. Once the missing values are identified, this PR currently propagates them through calculations (`use="everything"`), removes them (`use="na.rm"`) or produces an error (`use="all.obs"`). If `normalize=TRUE` and missing values are overlooked, `NA` values may propagate to the normalising constant and this will produce an error.