### PR TITLE
add annotation mapping for SummarizedExperiment and subclasses

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -29,7 +29,7 @@ setGeneric("wrapData",
            function(container, dataMatrix, geneSets) standardGeneric("wrapData"))
 
 setGeneric("mapGeneSetsToAnno",
-           function(geneSets, ...) standardGeneric("mapGeneSetsToAnno"))
+           function(geneSets, anno, ...) standardGeneric("mapGeneSetsToAnno"))
 
 setGeneric("get_exprData", function(object) standardGeneric("get_exprData"))
 

--- a/R/GsvaMethodParam.R
+++ b/R/GsvaMethodParam.R
@@ -122,25 +122,33 @@ setMethod("gsvaShow",
 setMethod("gsvaAnnotation",
           signature=signature(object="GsvaExprData"),
           function(object) {
-              return(NA_character_)
+              ## in general
+              return(NULL)
           })
 
 setMethod("gsvaAnnotation",
           signature=signature(object="ExpressionSet"),
           function(object) {
+              ## always a character giving the db pkg, potentially empty ("")
               return(annotation(object))
           })
 
 setMethod("gsvaAnnotation", signature("SummarizedExperiment"),
           function(object) {
-              a <- metadata(object)$annotation
-              return(if(.isCharLength1(a)) a else NA_character_)
+              ## NULL if unset; otherwise anything but we *expect* and handle
+              ## a GSEABase::GeneIdentifierType with or without annotation(),
+              ## i.e., db pkg, available.  Same for subclasses below.
+              return(metadata(object)$annotation)
           })
 
 setMethod("gsvaAnnotation", signature("SingleCellExperiment"),
           function(object) {
-              a <- metadata(object)$annotation
-              return(if(.isCharLength1(a)) a else NA_character_)
+              return(metadata(object)$annotation)
+          })
+
+setMethod("gsvaAnnotation", signature("SpatialExperiment"),
+          function(object) {
+              return(metadata(object)$annotation)
           })
 
 

--- a/R/gsvaNewAPI.R
+++ b/R/gsvaNewAPI.R
@@ -479,7 +479,8 @@ deduplicateGeneSets <- function(geneSets,
 
 
 deduplicateGmtLines <- function(geneSets,
-                                deduplUse = c("first", "drop", "union", "smallest", "largest")) {
+                                deduplUse = c("first", "drop", "union",
+                                              "smallest", "largest")) {
     ddUse <- match.arg(deduplUse)
     gsName <- sapply(geneSets, head, 1)
     isNameDuplicated <- which(duplicated(gsName))
@@ -774,18 +775,36 @@ setMethod("wrapData", signature(container="SpatialExperiment"),
 
 ## mapGeneSetsToAnno: translate feature IDs used in gene sets to specified
 ##                    annotation type (if any, and if possible)
-setMethod("mapGeneSetsToAnno", signature("list"),
+setMethod("mapGeneSetsToAnno", signature(geneSets="list", anno="NULL"),
           function(geneSets, anno) {
               return(geneSets)
           })
 
-setMethod("mapGeneSetsToAnno", signature("GeneSetCollection"),
+setMethod("mapGeneSetsToAnno", signature(geneSets="list", anno="character"),
+          function(geneSets, anno) {
+              return(geneSets)
+          })
+
+setMethod("mapGeneSetsToAnno",
+          signature(geneSets="list", anno="GeneIdentifierType"),
+          function(geneSets, anno) {
+              return(geneSets)
+          })
+
+setMethod("mapGeneSetsToAnno",
+          signature(geneSets="GeneSetCollection", anno="NULL"),
+          function(geneSets, anno) {
+              return(geneSets)
+          })
+
+setMethod("mapGeneSetsToAnno",
+          signature(geneSets="GeneSetCollection", anno="character"),
           function(geneSets, anno) {
               if(.isAnnoPkgValid(anno)) {
                   if(!.isAnnoPkgInstalled(anno))
                       stop(sprintf("Please install the annotation package %s. If %s does not seem to exist as a package, please try to append the suffix .db to its name.", anno, anno))
                   ## TODO: provide a check for verbosity
-                  cat("Mapping identifiers between gene sets and feature names\n")
+                  cat("Mapping identifiers between gene sets and feature names.\n")
 
                   ## map gene identifiers of the gene sets to the features in the chip
                   mappedGeneSets <- mapIdentifiers(geneSets,
@@ -796,6 +815,35 @@ setMethod("mapGeneSetsToAnno", signature("GeneSetCollection"),
                   ## TODO: provide a check for verbosity
                   cat("No annotation package name available in the input data object.",
                       "Attempting to directly match identifiers in data to gene sets.", sep="\n")
+
+                  rval <- geneIds(geneSets)
+              }
+
+              return(rval)
+          })
+
+setMethod("mapGeneSetsToAnno",
+          signature(geneSets="GeneSetCollection",
+                    anno="GeneIdentifierType"),
+          function(geneSets, anno) {
+              annoDb <- annotation(anno)
+
+              if(.isAnnoPkgValid(annoDb)) {
+                  if(!.isAnnoPkgInstalled(annoDb))
+                      stop(sprintf("Please install the annotation package %s. If %s does not seem to exist as a package, please try to append the suffix .db to its name.",
+                                   annoDb, annoDb))
+                  ## TODO: provide a check for verbosity
+                  cat("Mapping identifiers between gene sets and feature names.\n")
+
+                  ## map gene identifiers of the gene sets to the features in the chip
+                  mappedGeneSets <- mapIdentifiers(geneSets, anno)
+                  rval <- geneIds(mappedGeneSets)
+
+              } else {
+                  ## TODO: provide a check for verbosity
+                  cat("No annotation package name available in the input data object.",
+                      "Attempting to directly match identifiers in data to gene sets.",
+                      sep="\n")
 
                   rval <- geneIds(geneSets)
               }


### PR DESCRIPTION
This PR adds annotation mapping for `SummarizedExperiment` data containers and its subclasses `SingleCellExperiment` and `SpatialExperiment`. 

This will work if gene sets are stored in a `GeneSetCollection` with `geneIdType` set to a valid value e.g. by importing them using `GSEABase::getGmt()` or `GSVA::readGMT()`.  The container classes above need an `geneIdType` with an `OrgDb` as its `annotation()` set as the `annotation` element of their `metadata`, e.g. 
```
metadata(sce)$annotation <- ENSEMBLIdentifier("org.Hs.eg.db")
```
and any gene set IDs supported by `org.Hs.eg.db` will be automatically converted to ENSEMBL IDs.

Annotation mapping for `Biobase::ExpressionSet` containers has been verified to continue working where `annotation(ES)` is *not* a `geneIdType` but only a character containing the name of the annotation database package.

Annotation mapping for simpler container types such as `matrix` or `dgCMatrix` or with gene sets stored in lists is not supported.  

For performing/testing annotation mapping, it is sufficient to call `geneSets(par)` on a valid parameter object as described above, without running a complete gene set analysis.

