### PR TITLE
add new arguments for GSVA missing values to Shiny app

### DIFF
--- a/inst/shinyApp/argumentsDataModule.R
+++ b/inst/shinyApp/argumentsDataModule.R
@@ -46,8 +46,8 @@ argumentsDataServer <- function(id){
             toggleElement("ssgseaNorm", condition = input$method %in% "ssgsea")
             toggleElement("mxDiff", condition = input$method %in% "gsva")
             toggleElement("tau", condition = input$method %in% c("gsva", "ssgsea"))
-            toggleElement("checkNA", condition = input$method %in% "ssgsea")
-            toggleElement("use", condition = input$method %in% "ssgsea")
+            toggleElement("checkNA", condition = input$method %in% c("gsva", "ssgsea"))
+            toggleElement("use", condition = input$method %in% c("gsva", "ssgsea"))
             
             if(input$method == "gsva"){
                 updateNumericInput(inputId = "tau", value = 1)

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -88,7 +88,9 @@ function(input, output, session) {
                           kcdf=isolate(argInp[["kcdf"]]()),
                           tau=isolate(argInp[["selectedTau"]]()),
                           maxDiff=isolate(argInp[["mxDiff"]]()),
-                          absRanking=isolate(argInp[["absRanking"]]())))
+                          absRanking=isolate(argInp[["absRanking"]]()),
+                          checkNA=isolate(argInp[["checkNA"]]()),
+                          use=isolate(argInp[["use"]]())))
       result <- gsva(param=param, verbose=TRUE)
       sink()
       ## when gsva() ends, we reset the console text file to empty


### PR DESCRIPTION
This PR modifies the Shiny app to display two new arguments for the missing value policy of method GSVA and to use them when constructing the `gsvaParam` parameter object; similar to the recent extension for method ssGSEA.

Resolves #215 
