### PR TITLE
fix current and add extensive checking of assay names and assay argument

### DIFF
--- a/R/gsvaParam.R
+++ b/R/gsvaParam.R
@@ -150,14 +150,8 @@ gsvaParam <- function(exprData, geneSets,
     checkNA <- match.arg(checkNA)
     use <- match.arg(use)
 
-    an <- gsvaAssayNames(exprData)
-    if((!is.na(assay)) && (!.isCharNonEmpty(an))) {
-        msg <- sprintf(paste0("argument assay='%s' ignored since exprData has ",
-                              "no assayNames()"), assay)
-        cli_alert_info(msg)
-    }
-    if(is.na(assay) && .isCharNonEmpty(an))
-        assay <- na.omit(an)[1]
+    ## check assay parameter and assay names
+    assay <- .check_assayNames(assay, exprData)
 
     ## check for presence of valid row/feature names
     .check_rownames(exprData)

--- a/R/plageParam.R
+++ b/R/plageParam.R
@@ -66,14 +66,8 @@
 plageParam <- function(exprData, geneSets,
                        assay=NA_character_, annotation=NULL,
                        minSize=1, maxSize=Inf) {
-    an <- gsvaAssayNames(exprData)
-    if((!is.na(assay)) && (!.isCharNonEmpty(an))) {
-        msg <- sprintf(paste0("argument assay='%s' ignored since exprData has ",
-                              "no assayNames()"), assay)
-        cli_alert_info(msg)
-    }
-    if(is.na(assay) && .isCharNonEmpty(an))
-        assay <- na.omit(an)[1]
+    ## check assay parameter and assay names
+    assay <- .check_assayNames(assay, exprData)
 
     ## check for presence of valid row/feature names
     .check_rownames(exprData)

--- a/R/ssgseaParam.R
+++ b/R/ssgseaParam.R
@@ -107,14 +107,9 @@ ssgseaParam <- function(exprData, geneSets,
                         use=c("everything", "all.obs", "na.rm")) {
     checkNA <- match.arg(checkNA)
     use <- match.arg(use)
-    an <- gsvaAssayNames(exprData)
-    if((!is.na(assay)) && (!.isCharNonEmpty(an))) {
-        msg <- sprintf(paste0("argument assay='%s' ignored since exprData has ",
-                              "no assayNames()"), assay)
-        cli_alert_info(msg)
-    }
-    if(is.na(assay) && .isCharNonEmpty(an))
-        assay <- na.omit(an)[1]
+
+    ## check assay parameter and assay names
+    assay <- .check_assayNames(assay, exprData)
 
     ## check for presence of valid row/feature names
     .check_rownames(exprData)

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,6 +11,73 @@
 }
 
 
+## check if the expression data object at hand is a multi-assay container
+## required by .check_assayNames() (see below) but may be re-used elsewhere
+## *currently* only TRUE for SummarizedExperiment and its subclasses, else FALSE
+.isMultiAssayContainer <- function(xd) {
+    return(is(xd, "SummarizedExperiment"))
+}
+
+
+## check assay parameter and assay names:
+##   abort if selected assay name not found in existing assay name list
+##   alert if no assay name selected while there are assay names (and select
+##     the first one)
+##   alert if assay name selected while there are none
+##
+##   tricky: no assay names AND no assay name selected is the normal case for
+##     non-container data objects, e.g. matrix,  or single-assay containers,
+##     e.g. ExpressionSet, and should hence be silently accepted.  Multi-assay
+##     containers, e.g. SummarizedExperiment, MAY contain more than one assays
+##     BUT no assay names.  In this case we also abort because our parameter
+##     objects can only store assay names and we prefer requiring assay names
+##     for multi-assay containers (which is not unreasonable!) over making
+##     things even more complicated for little practical gain.
+.check_assayNames <- function(a, xd) {
+    an <- gsvaAssayNames(xd)
+
+    if(length(a) != 1) {
+        msg <- sprintf("argument 'assay' must be of length 1 (is %d)", length(a))
+        cli_abort(msg)
+    }
+    
+    if(.isCharNonEmpty(an)) {   # we have assay names
+        an <- .omitEmptyChar(an)
+        
+        if(is.na(a)) {          # but none selected: by default, use the first one
+            assay <- an[1]
+            msg <- sprintf("No assay name provided; using first assay '%s'", assay)
+            cli_alert_info(msg)
+        } else {                # check the provided assay name before using it
+            if(a %in% an) {
+                assay <- a      # found it: OK!
+            } else {            # assay name provided but not found: ERROR
+                msg <- sprintf(paste0("invalid argument assay='%s': not part of ",
+                                      "exprData's assay name list."), a)
+                cli_abort(msg)
+            }
+        }
+    } else {                    # we don't have no assay names at all
+        if(.isMultiAssayContainer(xd)) {  # these must have assay names: ERROR
+            msg <- sprintf("exprData object of class '%s' has no assay names.",
+                           class(xd))
+            cli_abort(msg)
+        } else {                # i.e. there is exactly one unnamed assay
+            if(!is.na(a)) {     # and the provided name is useless but harmless
+                msg <- sprintf(paste0("argument assay='%s' ignored since exprData ",
+                                      "has no assay names."), a)
+                cli_alert_info(msg)
+            }
+
+            assay <- NA_character_
+        }
+    }
+
+    return(assay)
+}
+
+
+
 ## 2024-02-06  axel: function .filterGenes() is intended to detect genes (rows)
 ##  with constant expression (and, hence, no information), warn about them and
 ##  optionally remove them (in particular, ssGSEA's choice is to keep them).
@@ -317,7 +384,15 @@
            (length(x) > 0) &&
            (is.character(x)) &&
            (!all(is.na(x))) &&
-           (any(nchar(x) > 0)))
+           any(nzchar(x)))
+}
+
+.omitEmptyChar <- function(x) {
+    if(.isCharNonEmpty(x)) {
+        return(x[(nzchar(x)) & (!is.na(x))])
+    } else {
+        return(character(0))
+    }
 }
 
 .isCharLength1 <- function(x) {

--- a/R/zscoreParam.R
+++ b/R/zscoreParam.R
@@ -68,14 +68,8 @@
 zscoreParam <- function(exprData, geneSets,
                         assay=NA_character_, annotation=NULL,
                         minSize=1,maxSize=Inf) {
-    an <- gsvaAssayNames(exprData)
-    if((!is.na(assay)) && (!.isCharNonEmpty(an))) {
-        msg <- sprintf(paste0("argument assay='%s' ignored since exprData has ",
-                              "no assayNames()"), assay)
-        cli_alert_info(msg)
-    }
-    if(is.na(assay) && .isCharNonEmpty(an))
-        assay <- na.omit(an)[1]
+    ## check assay parameter and assay names
+    assay <- .check_assayNames(assay, exprData)
 
     ## check for presence of valid row/feature names
     .check_rownames(exprData)


### PR DESCRIPTION
This PR fixes #229 

Bugs in the current implementation are fixed and more extensive checks of assay names and the `assay` argument are added. 

For multi-assay containers, i.e. `SummarizedExperiment` and its subclasses:
- check for at least one non-empty/non-`NA` assay name and abort with informative error message if none found
- fix the selection of the first one of these when no `assay` argument provided and inform user about it

For the `assay` argument:
- check for length 1 and abort with informative error message if different. (Also checked by parameter object validation -- too late, however, for the parameter object constructors)
- if provided in absence of assay names, ignore argument and inform user

If both assay names and `assay` argument are present, verify there is a match or abort with informative error message.

Implemented in `R/utils.R`, function `.check_assayNames()`, which is called by the parameter object constructors for all four supported methods.