### PR TITLE
232 R cmd check warning because of three undocumented arguments in spatcor

### DIFF
--- a/R/spatial.R
+++ b/R/spatial.R
@@ -34,7 +34,7 @@
 
 setMethod("spatCor", signature("SpatialExperiment"),
           function(spe, assay = NA_character_, na.rm = FALSE, alternative = "two.sided", squared = TRUE, verbose = TRUE, BPPARAM = SerialParam(progressbar = verbose)) {
-	    if(is.na(assay)) assay <- na.omit(assayNames(spe))[1]
+            assay <- .check_assayNames(assay, spe)
             weight_list <- .spe_dist_weight_matrix(spe,squared)
             rowns <- rownames(spe)
 	    df_res <- data.frame(observed = numeric(), expected = numeric(), sd = numeric(), p.value = numeric(), sample_id = character())

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -11,10 +11,16 @@
 #' assuming normality.
 #' 
 #' @param spe An object of \code{SpatialExperiment} class.
+#' @param assay Character vector of length 1, specifying the name of the assay to use.
+#' By default, the first assay is used.
 #' @param alternative A character string specifying the alternative hypothesis tested against the null hypothesis of no spatial autocorrelation;
 #'  must be one of "two.sided", "less", or "greater", or any unambiguous abbreviation of these.
 #' @param na.rm A logical indicating whether missing values should be removed.
 #' @param squared A logical indicating whether the inverse distance weight matrix should be squared or not.
+#' @param verbose Gives information about each calculation step. Default: `TRUE`.
+#' @param BPPARAM An object of class [`BiocParallelParam`] specifying parameters
+#'   related to the parallel execution of some of the tasks and calculations
+#'   within this function.
 #' 
 #' @return A \code{data.frame} with the same row names as the original \code{SpatialExperiment} object.
 	#' Columns include the observed Moran's I statistic, the expected Moran's I statistic under no spatial autocorrelation, the expected

--- a/man/spatCor.Rd
+++ b/man/spatCor.Rd
@@ -5,12 +5,21 @@
 \alias{spatCor,SpatialExperiment-method}
 \title{Compute Spatial Autocorrelation for SpatialExperiment objects}
 \usage{
-\S4method{spatCor}{SpatialExperiment}(spe, assay = NA_character_, na.rm = FALSE, alternative = "two.sided", squared = TRUE, verbose = TRUE, BPPARAM = SerialParam(progressbar = verbose))
+\S4method{spatCor}{SpatialExperiment}(
+  spe,
+  assay = NA_character_,
+  na.rm = FALSE,
+  alternative = "two.sided",
+  squared = TRUE,
+  verbose = TRUE,
+  BPPARAM = SerialParam(progressbar = verbose)
+)
 }
 \arguments{
 \item{spe}{An object of \code{SpatialExperiment} class.}
 
-\item{assay}{The name of the assay to use in case \code{spe} is a multi-assay container, otherwise ignored. By default, the first assay is used.}
+\item{assay}{Character vector of length 1, specifying the name of the assay to use.
+By default, the first assay is used.}
 
 \item{na.rm}{A logical indicating whether missing values should be removed.}
 
@@ -21,9 +30,10 @@ must be one of "two.sided", "less", or "greater", or any unambiguous abbreviatio
 
 \item{verbose}{Gives information about each calculation step. Default: \code{TRUE}.}
 
-\item{BPPARAM}{An object of class \code{\link{BiocParallelParam}} specifying parameters related to the parallel execution of some of the tasks and calculations within this function}
+\item{BPPARAM}{An object of class \code{\link{BiocParallelParam}} specifying parameters
+related to the parallel execution of some of the tasks and calculations
+within this function.}
 }
-
 \value{
 A \code{data.frame} with the same row names as the original \code{SpatialExperiment} object.
 Columns include the observed Moran's I statistic, the expected Moran's I statistic under no spatial autocorrelation, the expected


### PR DESCRIPTION

Added documentation for arguments `assay`, `verbose`, and `BPPARAM` to method `spatCor()` to make R CMD check happy.

Modified the first line of method `spatCor()` to use the new function `.check_assayNames()` to check for unnamed assays in `SummarizedExperiment` and subclasses and, if detected, print helpful error messages, the same way parameter object constructors do.

This fixes #232 