### PR TITLE
231 set default assay name to logcounts if applicable

### DIFF
--- a/R/gsvaParam.R
+++ b/R/gsvaParam.R
@@ -18,7 +18,8 @@
 #' 
 #' @param assay Character vector of length 1.  The name of the assay to use in
 #' case `exprData` is a multi-assay container, otherwise ignored.  By default,
-#' the first assay is used.
+#' an assay called 'logcounts' will be used if present, otherwise the first
+#' assay is used.
 #' 
 #' @param annotation An object of class [`GeneIdentifierType-class`] from
 #' package `GSEABase` describing the gene identifiers used as the row names of

--- a/R/plageParam.R
+++ b/R/plageParam.R
@@ -18,7 +18,8 @@
 #' 
 #' @param assay Character vector of length 1.  The name of the assay to use in
 #' case `exprData` is a multi-assay container, otherwise ignored.  By default,
-#' the first assay is used.
+#' an assay called 'logcounts' will be used if present, otherwise the first
+#' assay is used.
 #' 
 #' @param annotation An object of class [`GeneIdentifierType-class`] from
 #' package `GSEABase` describing the gene identifiers used as the row names of

--- a/R/ssgseaParam.R
+++ b/R/ssgseaParam.R
@@ -19,7 +19,8 @@
 #' 
 #' @param assay Character vector of length 1.  The name of the assay to use in
 #' case `exprData` is a multi-assay container, otherwise ignored.  By default,
-#' the first assay is used.
+#' an assay called 'logcounts' will be used if present, otherwise the first
+#' assay is used.
 #' 
 #' @param annotation An object of class [`GeneIdentifierType-class`] from
 #' package `GSEABase` describing the gene identifiers used as the row names of

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,6 +33,10 @@
 ##     objects can only store assay names and we prefer requiring assay names
 ##     for multi-assay containers (which is not unreasonable!) over making
 ##     things even more complicated for little practical gain.
+##
+## 2025-03-12  axel: as an afterthought, if we have a multi-assay container with
+##   assay names AND no assay is selected AND one of the assay names happens to
+##   be 'logcounts' --> use this one by default rather than the first in list.
 .check_assayNames <- function(a, xd) {
     an <- gsvaAssayNames(xd)
 
@@ -44,9 +48,13 @@
     if(.isCharNonEmpty(an)) {   # we have assay names
         an <- .omitEmptyChar(an)
         
-        if(is.na(a)) {          # but none selected: by default, use the first one
-            assay <- an[1]
-            msg <- sprintf("No assay name provided; using first assay '%s'", assay)
+        if(is.na(a)) {          # but none selected: by default, 
+            ## select a common value by default if available -- see afterthought
+            ## if unavailable, just select the first available assay name
+            def <- grep("logcounts", an, fixed=TRUE, value=TRUE)
+            assay <- if(length(def) > 0) head(def, 1) else head(an, 1)
+            msg <- sprintf("No assay name provided; using default assay '%s'",
+                           assay)
             cli_alert_info(msg)
         } else {                # check the provided assay name before using it
             if(a %in% an) {

--- a/R/zscoreParam.R
+++ b/R/zscoreParam.R
@@ -19,7 +19,8 @@
 #' 
 #' @param assay Character vector of length 1.  The name of the assay to use in
 #' case `exprData` is a multi-assay container, otherwise ignored.  By default,
-#' the first assay is used.
+#' an assay called 'logcounts' will be used if present, otherwise the first
+#' assay is used.
 #' 
 #' @param annotation An object of class [`GeneIdentifierType-class`] from
 #' package `GSEABase` describing the gene identifiers used as the row names of

--- a/man/gsvaParam-class.Rd
+++ b/man/gsvaParam-class.Rd
@@ -39,7 +39,8 @@ help page using \code{help(GsvaExprData)}.}
 
 \item{assay}{Character vector of length 1.  The name of the assay to use in
 case \code{exprData} is a multi-assay container, otherwise ignored.  By default,
-the first assay is used.}
+an assay called 'logcounts' will be used if present, otherwise the first
+assay is used.}
 
 \item{annotation}{An object of class \code{\linkS4class{GeneIdentifierType}} from
 package \code{GSEABase} describing the gene identifiers used as the row names of

--- a/man/plageParam-class.Rd
+++ b/man/plageParam-class.Rd
@@ -26,7 +26,8 @@ help page using \code{help(GsvaExprData)}.}
 
 \item{assay}{Character vector of length 1.  The name of the assay to use in
 case \code{exprData} is a multi-assay container, otherwise ignored.  By default,
-the first assay is used.}
+an assay called 'logcounts' will be used if present, otherwise the first
+assay is used.}
 
 \item{annotation}{An object of class \code{\linkS4class{GeneIdentifierType}} from
 package \code{GSEABase} describing the gene identifiers used as the row names of

--- a/man/spatCor.Rd
+++ b/man/spatCor.Rd
@@ -5,12 +5,18 @@
 \alias{spatCor,SpatialExperiment-method}
 \title{Compute Spatial Autocorrelation for SpatialExperiment objects}
 \usage{
-\S4method{spatCor}{SpatialExperiment}(spe, assay = NA_character_, na.rm = FALSE, alternative = "two.sided", squared = TRUE, verbose = TRUE, BPPARAM = SerialParam(progressbar = verbose))
+\S4method{spatCor}{SpatialExperiment}(
+  spe,
+  assay = NA_character_,
+  na.rm = FALSE,
+  alternative = "two.sided",
+  squared = TRUE,
+  verbose = TRUE,
+  BPPARAM = SerialParam(progressbar = verbose)
+)
 }
 \arguments{
 \item{spe}{An object of \code{SpatialExperiment} class.}
-
-\item{assay}{The name of the assay to use in case \code{spe} is a multi-assay container, otherwise ignored. By default, the first assay is used.}
 
 \item{na.rm}{A logical indicating whether missing values should be removed.}
 
@@ -18,12 +24,7 @@
 must be one of "two.sided", "less", or "greater", or any unambiguous abbreviation of these.}
 
 \item{squared}{A logical indicating whether the inverse distance weight matrix should be squared or not.}
-
-\item{verbose}{Gives information about each calculation step. Default: \code{TRUE}.}
-
-\item{BPPARAM}{An object of class \code{\link{BiocParallelParam}} specifying parameters related to the parallel execution of some of the tasks and calculations within this function}
 }
-
 \value{
 A \code{data.frame} with the same row names as the original \code{SpatialExperiment} object.
 Columns include the observed Moran's I statistic, the expected Moran's I statistic under no spatial autocorrelation, the expected

--- a/man/ssgseaParam-class.Rd
+++ b/man/ssgseaParam-class.Rd
@@ -41,7 +41,8 @@ help page using \code{help(GsvaExprData)}.}
 
 \item{assay}{Character vector of length 1.  The name of the assay to use in
 case \code{exprData} is a multi-assay container, otherwise ignored.  By default,
-the first assay is used.}
+an assay called 'logcounts' will be used if present, otherwise the first
+assay is used.}
 
 \item{annotation}{An object of class \code{\linkS4class{GeneIdentifierType}} from
 package \code{GSEABase} describing the gene identifiers used as the row names of

--- a/man/zscoreParam-class.Rd
+++ b/man/zscoreParam-class.Rd
@@ -26,7 +26,8 @@ help page using \code{help(GsvaExprData)}.}
 
 \item{assay}{Character vector of length 1.  The name of the assay to use in
 case \code{exprData} is a multi-assay container, otherwise ignored.  By default,
-the first assay is used.}
+an assay called 'logcounts' will be used if present, otherwise the first
+assay is used.}
 
 \item{annotation}{An object of class \code{\linkS4class{GeneIdentifierType}} from
 package \code{GSEABase} describing the gene identifiers used as the row names of


### PR DESCRIPTION

This PR resolves #231 

Implements the following behaviour as described in issue #231: for all parameter object constructor and now also for method `spatCor()`, by default, i.e. if no value is provided for argument `assay`, and an assay named 'logcounts´ exists in the provided multi-assay data container object, then select this assay 'logcounts', otherwise select the first available assay.

This is supposed to be helpful in cases where computational pipelines create an assay 'logcounts' based on an initial assay 'counts' which would be first by conventional ordering but not the best choice for further processing.
