### PR TITLE
fix NOTE about 'non-topic package-anchored links'

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -12,7 +12,12 @@
 #' @seealso
 #' [`matrix`],
 #' [`dgcMatrix`][Matrix::dgCMatrix-class],
-#' [`ExpressionSet`][Biobase::ExpressionSet-class],
+#' \code{\link[Biobase]{ExpressionSet}},
+### we are using the plain Rd above because
+###  #' [`ExpressionSet`][Biobase::ExpressionSet-class],
+### results in the following R CMD check NOTE:
+### Non-topic package-anchored link(s) in Rd file 'gsvaExprData-class.Rd':
+###  ‘[Biobase:class.ExpressionSet]{ExpressionSet}’
 #' [`SummarizedExperiment`][SummarizedExperiment::SummarizedExperiment-class],
 #' [`SingleCellExperiment`][SingleCellExperiment::SingleCellExperiment-class],
 #' [`SpatialExperiment`][SpatialExperiment::SpatialExperiment-class]

--- a/R/gsva.R
+++ b/R/gsva.R
@@ -277,7 +277,12 @@ compute.geneset.es <- function(expr, gset.idx.list, sample.idxs, kcdf,
 #' @seealso [`gsvaParam-class`], [`gsvaRanksParam-class`], [`gsva`],
 #' [`BiocParallelParam`][BiocParallel::BiocParallelParam-class],
 #' [`dgCMatrix`][Matrix::dgCMatrix-class],
-#' [`ExpressionSet`][Biobase::ExpressionSet-class],
+#' \code{\link[Biobase]{ExpressionSet}},
+### we are using the plain Rd above because
+###  #' [`ExpressionSet`][Biobase::ExpressionSet-class],
+### results in the following R CMD check NOTE:
+### Non-topic package-anchored link(s) in Rd file 'gsvaRanks.Rd':
+###  ‘[Biobase:class.ExpressionSet]{ExpressionSet}’
 #' [`SingleCellExperiment`][SingleCellExperiment::SingleCellExperiment-class]
 #'
 #' @aliases gsvaRanks,gsvaParam-method

--- a/R/gsvaNewAPI.R
+++ b/R/gsvaNewAPI.R
@@ -44,7 +44,12 @@
 #' @seealso [`plageParam`], [`zscoreParam`], [`ssgseaParam`], [`gsvaParam`],
 #' [`BiocParallelParam`][BiocParallel::BiocParallelParam-class],
 #' [`dgCMatrix`][Matrix::dgCMatrix-class],
-#' [`ExpressionSet`][Biobase::ExpressionSet-class],
+#' \code{\link[Biobase]{ExpressionSet}},
+### we are using the plain Rd above because
+###  #' [`ExpressionSet`][Biobase::ExpressionSet-class],
+### results in the following R CMD check NOTE:
+### Non-topic package-anchored link(s) in Rd file 'gsva.Rd':
+###  ‘[Biobase:class.ExpressionSet]{ExpressionSet}’
 #' [`SingleCellExperiment`][SingleCellExperiment::SingleCellExperiment-class]
 #'
 #' @aliases gsva
@@ -338,7 +343,13 @@ setMethod("gsva", signature(param="gsvaParam"),
 #' @return For the retrieval methods, the annotation metadata stored in the
 #' object or `NULL`.  For the replacement methods, the updated object.
 #'
-#' @seealso [`ExpressionSet`][Biobase::ExpressionSet-class],
+#' @seealso
+#' \code{\link[Biobase]{ExpressionSet}},
+### we are using the plain Rd above because
+###  #' [`ExpressionSet`][Biobase::ExpressionSet-class],
+### results in the following R CMD check NOTE:
+### Non-topic package-anchored link(s) in Rd file 'gsvaAnnotation.Rd':
+###  ‘[Biobase:class.ExpressionSet]{ExpressionSet}’
 #' [`SummarizedExperiment`][SummarizedExperiment::SummarizedExperiment-class],
 #' [`GeneIdentifierType`][GSEABase::GeneIdentifierType-class],
 #' [`dgCMatrix`][Matrix::dgCMatrix-class]
@@ -904,7 +915,12 @@ geneIdsToGeneSetCollection <- function(geneIdsList,
 #' @seealso [`readLines`],
 #' [`GeneSetCollection`][GSEABase::GeneSetCollection-class],
 #' [`GeneIdentifierType`][GSEABase::GeneIdentifierType-class],
-#' [`getGmt`][GSEABase::getGmt]
+#' \code{\link[GSEABase]{getGmt}},
+### we are using the plain Rd above because
+###  #' [`getGmt`][GSEABase::getGmt]
+### results in the following R CMD check NOTE:
+### Non-topic package-anchored link(s) in Rd file 'readGMT.Rd':
+###   ‘[GSEABase:getObjects]{getGmt}’
 #'
 #' @examples
 #' library(GSVA)

--- a/R/gsvaParam.R
+++ b/R/gsvaParam.R
@@ -117,7 +117,12 @@
 #'
 #' @seealso [`GeneIdentifierType`][GSEABase::GeneIdentifierType-class],
 #' [`matrix`],
-#' [`ExpressionSet`][Biobase::ExpressionSet-class],
+#' \code{\link[Biobase]{ExpressionSet}},
+### we are using the plain Rd above because
+###  #' [`ExpressionSet`][Biobase::ExpressionSet-class],
+### results in the following R CMD check NOTE:
+### Non-topic package-anchored link(s) in Rd file 'gsvaParam-class.Rd':
+###  ‘[Biobase:class.ExpressionSet]{ExpressionSet}’
 #' [`SummarizedExperiment`][SummarizedExperiment::SummarizedExperiment-class],
 #' [`SingleCellExperiment`][SingleCellExperiment::SingleCellExperiment-class]
 #'

--- a/R/ssgseaParam.R
+++ b/R/ssgseaParam.R
@@ -80,7 +80,12 @@
 #'
 #' @seealso [`GeneIdentifierType`][GSEABase::GeneIdentifierType-class],
 #' [`matrix`],
-#' [`ExpressionSet`][Biobase::ExpressionSet-class],
+#' \code{\link[Biobase]{ExpressionSet}},
+### we are using the plain Rd above because
+###  #' [`ExpressionSet`][Biobase::ExpressionSet-class],
+### results in the following R CMD check NOTE:
+### Non-topic package-anchored link(s) in Rd file 'ssgseaParam-class.Rd':
+###  ‘[Biobase:class.ExpressionSet]{ExpressionSet}’
 #' [`SummarizedExperiment`][SummarizedExperiment::SummarizedExperiment-class],
 #' [`SingleCellExperiment`][SingleCellExperiment::SingleCellExperiment-class]
 #'

--- a/man/GsvaExprData-class.Rd
+++ b/man/GsvaExprData-class.Rd
@@ -16,7 +16,7 @@ of another class as well as defining common methods for all of them.
 \seealso{
 \code{\link{matrix}},
 \code{\link[Matrix:dgCMatrix-class]{dgcMatrix}},
-\code{\link[Biobase:class.ExpressionSet]{ExpressionSet}},
+\code{\link[Biobase]{ExpressionSet}},
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}},
 \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment}},
 \code{\link[SpatialExperiment:SpatialExperiment]{SpatialExperiment}}

--- a/man/gsva.Rd
+++ b/man/gsva.Rd
@@ -134,6 +134,6 @@ using singular value decomposition.
 \code{\link{plageParam}}, \code{\link{zscoreParam}}, \code{\link{ssgseaParam}}, \code{\link{gsvaParam}},
 \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}},
 \code{\link[Matrix:dgCMatrix-class]{dgCMatrix}},
-\code{\link[Biobase:class.ExpressionSet]{ExpressionSet}},
+\code{\link[Biobase]{ExpressionSet}},
 \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment}}
 }

--- a/man/gsvaAnnotation.Rd
+++ b/man/gsvaAnnotation.Rd
@@ -76,7 +76,7 @@ an MSigDb gene set using ENTREZ IDs or gene symbols to an expression data
 set using ENSEMBL IDs.
 }
 \seealso{
-\code{\link[Biobase:class.ExpressionSet]{ExpressionSet}},
+\code{\link[Biobase]{ExpressionSet}},
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}},
 \code{\link[GSEABase:GeneIdentifierType-class]{GeneIdentifierType}},
 \code{\link[Matrix:dgCMatrix-class]{dgCMatrix}}

--- a/man/gsvaParam-class.Rd
+++ b/man/gsvaParam-class.Rd
@@ -257,7 +257,7 @@ variation analysis for microarray and RNA-Seq data.
 
 \code{\link[GSEABase:GeneIdentifierType-class]{GeneIdentifierType}},
 \code{\link{matrix}},
-\code{\link[Biobase:class.ExpressionSet]{ExpressionSet}},
+\code{\link[Biobase]{ExpressionSet}},
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}},
 \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment}}
 }

--- a/man/gsvaRanks.Rd
+++ b/man/gsvaRanks.Rd
@@ -99,6 +99,6 @@ variation analysis for microarray and RNA-Seq data.
 \code{\linkS4class{gsvaParam}}, \code{\linkS4class{gsvaRanksParam}}, \code{\link{gsva}},
 \code{\link[BiocParallel:BiocParallelParam-class]{BiocParallelParam}},
 \code{\link[Matrix:dgCMatrix-class]{dgCMatrix}},
-\code{\link[Biobase:class.ExpressionSet]{ExpressionSet}},
+\code{\link[Biobase]{ExpressionSet}},
 \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment}}
 }

--- a/man/readGMT.Rd
+++ b/man/readGMT.Rd
@@ -104,5 +104,5 @@ gsvaAnnotation(genesets)
 \code{\link{readLines}},
 \code{\link[GSEABase:GeneSetCollection-class]{GeneSetCollection}},
 \code{\link[GSEABase:GeneIdentifierType-class]{GeneIdentifierType}},
-\code{\link[GSEABase:getObjects]{getGmt}}
+\code{\link[GSEABase]{getGmt}},
 }

--- a/man/ssgseaParam-class.Rd
+++ b/man/ssgseaParam-class.Rd
@@ -176,7 +176,7 @@ oncogenic KRAS-driven cancers require TBK1.
 
 \code{\link[GSEABase:GeneIdentifierType-class]{GeneIdentifierType}},
 \code{\link{matrix}},
-\code{\link[Biobase:class.ExpressionSet]{ExpressionSet}},
+\code{\link[Biobase]{ExpressionSet}},
 \code{\link[SummarizedExperiment:SummarizedExperiment-class]{SummarizedExperiment}},
 \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment}}
 }


### PR DESCRIPTION

... by using plain Rd inside the `roxygen2` documentation that avoids being translated into an Rd `\link{}` that receives a `NOTE` from recent versions of `R CMD check`, along with a comment explaining this workaround so it can be removed should this behaviour be fixed but not otherwise.

Finally closes #235 

