### PR TITLE
use a smaller GMT file in the example for readGMT() and suppress pack…

### DIFF
--- a/R/gsvaNewAPI.R
+++ b/R/gsvaNewAPI.R
@@ -924,17 +924,22 @@ geneIdsToGeneSetCollection <- function(geneIdsList,
 #'
 #' @examples
 #' library(GSVA)
-#' library(GSVAdata)
+#' suppressPackageStartupMessages(library(GSVAdata))
 #'
-#' fname <- system.file("extdata", "c7.immunesigdb.v2024.1.Hs.symbols.gmt.gz",
-#'                      package="GSVAdata")
-#'
+#' fname <- file.path(system.file("extdata", package="GSVAdata"),
+#'    "c2.subsetdups.v7.5.symbols.gmt.gz")
+#' 
 #' ## by default, guess geneIdType from content and return a GeneSetCollection
 #' genesets <- readGMT(fname)
 #' genesets
 #'
 #' ## how to manually override the geneIdType
 #' genesets <- readGMT(fname, geneIdType=NullIdentifier())
+#' genesets
+#' 
+#' ## how to drop *all* gene sets with duplicated names (instead of ignoring
+#' ## only the duplicated one)
+#' genesets <- readGMT(fname, deduplUse="drop")
 #' genesets
 #' 
 #' ## return a simple list instead of a GeneSetCollection

--- a/R/gsvaParam.R
+++ b/R/gsvaParam.R
@@ -133,7 +133,7 @@
 #'
 #' @examples
 #' library(GSVA)
-#' library(GSVAdata)
+#' suppressPackageStartupMessages(library(GSVAdata))
 #'
 #' data(leukemia)
 #' data(c2BroadSets)

--- a/R/plageParam.R
+++ b/R/plageParam.R
@@ -51,7 +51,7 @@
 #'
 #' @examples
 #' library(GSVA)
-#' library(GSVAdata)
+#' suppressPackageStartupMessages(library(GSVAdata))
 #'
 #' data(leukemia)
 #' data(c2BroadSets)

--- a/R/ssgseaParam.R
+++ b/R/ssgseaParam.R
@@ -96,7 +96,7 @@
 #' 
 #' @examples
 #' library(GSVA)
-#' library(GSVAdata)
+#' suppressPackageStartupMessages(library(GSVAdata))
 #'
 #' data(leukemia)
 #' data(c2BroadSets)

--- a/R/zscoreParam.R
+++ b/R/zscoreParam.R
@@ -52,7 +52,7 @@
 #'
 #' @examples
 #' library(GSVA)
-#' library(GSVAdata)
+#' suppressPackageStartupMessages(library(GSVAdata))
 #'
 #' data(leukemia)
 #' data(c2BroadSets)

--- a/man/gsvaParam-class.Rd
+++ b/man/gsvaParam-class.Rd
@@ -228,7 +228,7 @@ to apply in the presence of missing values in the input expression data; see
 
 \examples{
 library(GSVA)
-library(GSVAdata)
+suppressPackageStartupMessages(library(GSVAdata))
 
 data(leukemia)
 data(c2BroadSets)

--- a/man/plageParam-class.Rd
+++ b/man/plageParam-class.Rd
@@ -68,7 +68,7 @@ These parameters are described in detail below.
 }
 \examples{
 library(GSVA)
-library(GSVAdata)
+suppressPackageStartupMessages(library(GSVAdata))
 
 data(leukemia)
 data(c2BroadSets)

--- a/man/readGMT.Rd
+++ b/man/readGMT.Rd
@@ -79,10 +79,10 @@ format file, offering a choice of ways to handle duplicated gene set names.
 }
 \examples{
 library(GSVA)
-library(GSVAdata)
+suppressPackageStartupMessages(library(GSVAdata))
 
-fname <- system.file("extdata", "c7.immunesigdb.v2024.1.Hs.symbols.gmt.gz",
-                     package="GSVAdata")
+fname <- file.path(system.file("extdata", package="GSVAdata"),
+   "c2.subsetdups.v7.5.symbols.gmt.gz")
 
 ## by default, guess geneIdType from content and return a GeneSetCollection
 genesets <- readGMT(fname)
@@ -90,6 +90,11 @@ genesets
 
 ## how to manually override the geneIdType
 genesets <- readGMT(fname, geneIdType=NullIdentifier())
+genesets
+
+## how to drop *all* gene sets with duplicated names (instead of ignoring
+## only the duplicated one)
+genesets <- readGMT(fname, deduplUse="drop")
 genesets
 
 ## return a simple list instead of a GeneSetCollection

--- a/man/ssgseaParam-class.Rd
+++ b/man/ssgseaParam-class.Rd
@@ -148,7 +148,7 @@ to apply in the presence of missing values in the input expression data; see
 
 \examples{
 library(GSVA)
-library(GSVAdata)
+suppressPackageStartupMessages(library(GSVAdata))
 
 data(leukemia)
 data(c2BroadSets)

--- a/man/zscoreParam-class.Rd
+++ b/man/zscoreParam-class.Rd
@@ -69,7 +69,7 @@ These parameters are described in detail below.
 }
 \examples{
 library(GSVA)
-library(GSVAdata)
+suppressPackageStartupMessages(library(GSVAdata))
 
 data(leukemia)
 data(c2BroadSets)


### PR DESCRIPTION
…age startup messages in all examples

This PR fixes #240 
1. uses a smaller GMT file from package `GSVAdata` that can be read in about 1s *and* contains duplicated gene set names for demonstration purposes
2. adds an example for using a non-default strategy of handling duplicated gene set names in a GMT file, and
3. uses `suppressPackageStartupMessages()` whenever package `GSVAdata` is loaded

